### PR TITLE
Update typings and package.json types as per latest Typescript specs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,58 @@
+// Type definitions for react-chartjs-2 2.0
+// Project: https://github.com/gor181/react-chartjs-2
+// Definitions by: Alexandre Paré <https://github.com/apare>
+//                 Fabien Lavocat <https://github.com/FabienLavocat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-import * as React from 'react';
+import * as React from "react";
+import * as chartjs from "chart.js";
 
-interface ChartComponentProps {
-	data :Object;
-	height? :number;
-	legend? :Object;
-	onElementsClick? :Function;
-	options? :Object;
-	redraw? :boolean;
-	type? :String;
-	width? :number;
+export type ChartDataFunction<T extends chartjs.ChartData> = (element: HTMLElement) => T;
+export type ChartData<T extends chartjs.ChartData> = ChartDataFunction<T> | T;
+
+export interface ChartComponentProps {
+  data: ChartData<chartjs.ChartData>;
+  type?: chartjs.ChartType;
+  getDatasetAtEvent?(e: any): void;
+  getElementAtEvent?(e: any): void;
+  getElementsAtEvent?(e: any): void;
+  height?: number;
+  legend?: chartjs.ChartLegendOptions;
+  onElementsClick?(e: any): void; // alias for getElementsAtEvent (backward compatibility)
+  options?: chartjs.ChartOptions;
+  redraw?: boolean;
+  width?: number;
 }
 
-export class Doughnut extends React.Component<ChartComponentProps, any>{}
-export class Pie extends React.Component<ChartComponentProps, any>{}
-export class Line extends React.Component<ChartComponentProps, any>{}
-export class Bar extends React.Component<ChartComponentProps, any>{}
-export class HorizontalBar extends React.Component<ChartComponentProps, any>{}
-export class Radar extends React.Component<ChartComponentProps, any>{}
-export class Polar extends React.Component<ChartComponentProps, any>{}
-export class Scatter extends React.Component<ChartComponentProps, any>{}
+export interface LinearComponentProps extends ChartComponentProps {
+  data: ChartData<chartjs.ChartData>;
+}
+
+export default class ChartComponent<P extends ChartComponentProps> extends React.Component<P> {
+  chart_instance: chartjs;
+}
+
+export class Doughnut extends ChartComponent<ChartComponentProps> {
+}
+
+export class Pie extends ChartComponent<ChartComponentProps> {
+}
+
+export class Line extends ChartComponent<LinearComponentProps> {
+}
+
+export class Bar extends ChartComponent<LinearComponentProps> {
+}
+
+export class HorizontalBar extends ChartComponent<ChartComponentProps> {
+}
+
+export class Radar extends ChartComponent<ChartComponentProps> {
+}
+
+export class Polar extends ChartComponent<ChartComponentProps> {
+}
+
+export class Bubble extends ChartComponent<ChartComponentProps> {
+}

--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
     "chart.js",
     "react-chartjs-2",
     "react chart.js"
-  ]
+  ],
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
- It looks like the current `index.d.ts` doesn't contain all of the interface props that ChartJS requires.

- Also, https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html defines the spec for types in package.json as:

```If your package has a main .js file, you will need to indicate the main declaration file in your package.json file as well. Set the types property to point to your bundled declaration file. For example:

{
    "name": "awesome",
    "author": "Vandelay Industries",
    "version": "1.0.0",
    "main": "./lib/main.js",
    "types": "./lib/main.d.ts"
}
```