### PR TITLE
add typings for scatter plot

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,8 @@ export class Pie extends ChartComponent<ChartComponentProps> {}
 
 export class Line extends ChartComponent<LinearComponentProps> {}
 
+export class Scatter extends ChartComponent<ChartComponentProps> {}
+
 export class Bar extends ChartComponent<LinearComponentProps> {}
 
 export class HorizontalBar extends ChartComponent<ChartComponentProps> {}


### PR DESCRIPTION
The scatter chart was missing from the typescript declaration file

cheers,

Pete