### PR TITLE
Use real lodash instead of custom `lodash.*` builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "url": "https://github.com/jerairrest/react-chartjs-2/issues"
   },
   "dependencies": {
-    "lodash.find": "^4.6.0",
-    "lodash.isequal": "^4.4.0",
+    "lodash": "^4.17.4",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Chart from 'chart.js';
-import isEqual from 'lodash.isequal';
-import find from 'lodash.find';
+import isEqual from 'lodash/isEqual';
+import find from 'lodash/find';
 
 
 class ChartComponent extends React.Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,10 +4727,6 @@ lodash.filter@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-
 lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
@@ -4746,10 +4742,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isequal@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isplainobject@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Most people use lodash and not `lodash.isequal` or `lodash.find`. They are custom builds of lodash, with a lot of duplicated code, and results in really heavy bundles.

Today I have to alias `lodash.find` to `lodash/find` and `lodash.isequal` to `lodash/isEqual` in my apps in order to prevent the duplicated code.

For reference, for [etalab/inspire](github.com/etalab/inspire), my output bundle is 5.88 KB (gzipped) heavier when I’m not aliasing lodash.find and lodash.isequal to their counterparts in lodash.


---

Before:
```
$ ll dist
total 392
-rw-r--r--  1 tusbar  staff   156K Aug 19 15:41 react-chartjs-2.js
-rw-r--r--  1 tusbar  staff    37K Aug 19 15:41 react-chartjs-2.min.js
```

After:
```
$ ll dist 
total 312
-rw-r--r--  1 tusbar  staff   124K Aug 19 15:40 react-chartjs-2.js
-rw-r--r--  1 tusbar  staff    30K Aug 19 15:40 react-chartjs-2.min.js
```