### PR TITLE
fix for storybook cannot resolve module react-chartjs-2

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'react-chartjs-2': path.join(__dirname, '../src'),
+    },
+  },
+}


### PR DESCRIPTION
- adds webpack alias for react-chartjs-2