### PR TITLE
Added id prop to the canvas component

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ import {Doughnut} from 'react-chartjs-2';
 * data: (PropTypes.object | PropTypes.func).isRequired,
 * width: PropTypes.number,
 * height: PropTypes.number,
+* id: PropTypes.string,
 * legend: PropTypes.object,
 * options: PropTypes.object,
 * redraw: PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -260,13 +260,14 @@ class ChartComponent extends React.Component {
   }
 
   render() {
-    const {height, width, onElementsClick} = this.props;
+    const {height, width, onElementsClick, id} = this.props;
 
     return (
       <canvas
         ref={this.ref}
         height={height}
         width={width}
+        id={id}
         onClick={this.handleOnClick}
       />
     );


### PR DESCRIPTION
In order to operate on the `canvas` object directly, you should be able to assign an `id` attribute to it.