### PR TITLE
Fix UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "sinon": "^1.17.6",
     "webpack": "^3.5.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import uglify from 'rollup-plugin-uglify';
+import replace from 'rollup-plugin-replace';
 
 const env = process.env.NODE_ENV;
 
@@ -24,6 +25,8 @@ const config = {
   ],
 };
 
+
+
 if (env === 'production') {
    config.plugins.push(
     uglify({
@@ -35,6 +38,12 @@ if (env === 'production') {
       },
     })
   );
+
+  config.plugins.push(
+    replace({
+      'process.env.NODE_ENV': JSON.stringify( 'production' )
+    })
+  )
 }
 
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,6 +4825,12 @@ magic-string@^0.19.0:
   dependencies:
     vlq "^0.2.1"
 
+magic-string@^0.22.4:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  dependencies:
+    vlq "^0.2.2"
+
 make-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
@@ -6559,6 +6565,14 @@ rollup-plugin-node-resolve@^3.0.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-replace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
+  dependencies:
+    magic-string "^0.22.4"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
 rollup-plugin-uglify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz#67b37ad1efdafbd83af4c36b40c189ee4866c969"
@@ -7506,6 +7520,10 @@ vinyl@^0.5.0:
 vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 vm-browserify@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Fixes UMD builds be injecting 'production' into where process.env.NODE_ENV exists. Should  
- https://github.com/jerairrest/react-chartjs-2/issues/277
- https://github.com/jerairrest/react-chartjs-2/issues/291
- https://github.com/jerairrest/react-chartjs-2/issues/277 