### PR TITLE
Fix datasetKeyProvider typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export interface ChartComponentProps {
   plugins?: object[];
   redraw?: boolean;
   width?: number;
-  datasetKeyProvider: (any) => any;
+  datasetKeyProvider?: (any: any) => any;
 }
 
 export interface LinearComponentProps extends ChartComponentProps {


### PR DESCRIPTION
- The lack of type for the argument breaks when TypeScript's `noImplicitAny` is enabled
- `datasetKeyProvider` is optional, as it defaults to `ChartComponent.getLabelAsKey`