### PR TITLE
upgrade chart.js 2.7.2 and fix #247

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "es/index.js",
   "author": "Jeremy Ayerst",
   "homepage": "https://github.com/jerairrest/react-chartjs-2",
-  "license" : "MIT" ,
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jerairrest/react-chartjs-2.git"
@@ -35,7 +35,7 @@
     "canvas": "^1.6.2",
     "canvas-prebuilt": "^1.6.5-prerelease.1",
     "chai": "^3.5.0",
-    "chart.js": "2.6.0",
+    "chart.js": "2.7.2",
     "cross-env": "^5.0.0",
     "css-loader": "^0.28.5",
     "debug": "^2.4.1",

--- a/stories/MixLineBar.js
+++ b/stories/MixLineBar.js
@@ -19,9 +19,7 @@ const options = {
         gridLines: {
           display: false
         },
-        labels: {
-          show: true
-        }
+        labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July']
       }
     ],
     yAxes: [
@@ -56,7 +54,6 @@ const options = {
 storiesOf('Mix Line+Bar Example', module)
   .add('Line & Bar Stacked', () => {
     const data = {
-      labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
       datasets: [{
         label: 'Sales',
         type:'line',
@@ -85,7 +82,6 @@ storiesOf('Mix Line+Bar Example', module)
   })
   .add('Line & Line Stacked', () => {
     const data = {
-      labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
       datasets: [{
         label: 'Sales',
         type:'line',
@@ -114,7 +110,6 @@ storiesOf('Mix Line+Bar Example', module)
   })
   .add('Line & Line Past vs. Future', () => {
     const data = {
-      labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
       datasets: [{
         label: 'Past',
         type:'line',
@@ -174,9 +169,7 @@ storiesOf('Mix Line+Bar Example', module)
             gridLines: {
               display: false
             },
-            labels: {
-              show: true
-            }
+            labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
           }
         ],
         yAxes: [


### PR DESCRIPTION
- Simply upgraded chart.js to 2.7.2
  - this version contains a stacked group's bugfix https://github.com/chartjs/Chart.js/pull/4937
- fixed #247 
