### PR TITLE
Removed default `height` and `width` props in favor of `aspectRatio`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,9 +10,9 @@
 	"rules": {
 		"curly": [2, "multi-line"],
 		"quotes": [2, "single", "avoid-escape"],
+		"jsx-quotes": 1,
 		"react/display-name": 0,
 		"react/jsx-boolean-value": 1,
-		"react/jsx-quotes": 1,
 		"react/jsx-no-undef": 1,
 		"react/jsx-sort-props": 0,
 		"react/jsx-sort-prop-types": 1,

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-chartjs-2",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "react-chartjs-2",
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "author": "Jeremy Ayerst",
   "homepage": "https://github.com/jerairrest/react-chartjs-2",
-  "license" : "MIT" ,
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jerairrest/react-chartjs-2.git"

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,12 @@ class ChartComponent extends React.Component {
       PropTypes.object,
       PropTypes.func
     ]).isRequired,
+    datasetKeyProvider: PropTypes.func,
     getDatasetAtEvent: PropTypes.func,
     getElementAtEvent: PropTypes.func,
     getElementsAtEvent: PropTypes.func,
     height: PropTypes.number,
+    id: PropTypes.string,
     legend: PropTypes.object,
     onElementsClick: PropTypes.func,
     options: PropTypes.object,
@@ -32,7 +34,6 @@ class ChartComponent extends React.Component {
       }
     },
     width: PropTypes.number,
-    datasetKeyProvider: PropTypes.func
   }
 
   static defaultProps = {
@@ -41,10 +42,10 @@ class ChartComponent extends React.Component {
       position: 'bottom'
     },
     type: 'doughnut',
-    height: 150,
-    width: 300,
     redraw: false,
-    options: {},
+    options: {
+      aspectRatio: 2
+    },
     datasetKeyProvider: ChartComponent.getLabelAsKey
   }
 
@@ -281,7 +282,7 @@ export class Doughnut extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='doughnut'
+        type="doughnut"
       />
     );
   }
@@ -293,7 +294,7 @@ export class Pie extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='pie'
+        type="pie"
       />
     );
   }
@@ -305,7 +306,7 @@ export class Line extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='line'
+        type="line"
       />
     );
   }
@@ -317,7 +318,7 @@ export class Bar extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='bar'
+        type="bar"
       />
     );
   }
@@ -329,7 +330,7 @@ export class HorizontalBar extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='horizontalBar'
+        type="horizontalBar"
       />
     );
   }
@@ -341,7 +342,7 @@ export class Radar extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='radar'
+        type="radar"
       />
     );
   }
@@ -353,7 +354,7 @@ export class Polar extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='polarArea'
+        type="polarArea"
       />
     );
   }
@@ -365,7 +366,7 @@ export class Bubble extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='bubble'
+        type="bubble"
       />
     );
   }
@@ -377,7 +378,7 @@ export class Scatter extends React.Component {
       <ChartComponent
         {...this.props}
         ref={ref => this.chartInstance = ref && ref.chartInstance}
-        type='scatter'
+        type="scatter"
       />
     );
   }


### PR DESCRIPTION
In this PR, I have removed the defaultProps for `height` and `width` in favor of the `aspectRatio` option to control the initial canvas aspect ratio to be 2.

The result of this is more intuitive control over the aspect ratio and size of each chart. The reasoning behind this can be found [in the docs](https://www.chartjs.org/docs/latest/general/responsive.html) under the `Configuration Options` and `aspectRatio` with the following quote:

> Note that this option is ignored if the height is explicitly defined either as attribute or via the style.

This will enabled users to use the `aspectRatio` option without providing `height` and `width` an empty string or null value.

Also in this PR:
- `"react/jsx-quotes": 1` changed to `"jsx-quotes": 1` as the prior has been deprecated
- JSX quotes changed in accordance with linting warnings in `src/index.js`
- Moved `datasetKeyProvider: PropTypes.func` to be alphabetical in accordance with linting
- Added `id: PropTypes.string` to due to proptypes linting warning
- Package version bumped by from `2.7.4` to `2.7.5`