### PR TITLE
Allow global defaults to be set in Typescript without type errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,4 +57,7 @@ export class Polar extends ChartComponent<ChartComponentProps> {}
 
 export class Bubble extends ChartComponent<ChartComponentProps> {}
 
-export var defaults: {};
+export var defaults: {
+  global: chartjs.ChartOptions & chartjs.ChartFontOptions;
+  [key: string]: any;
+};


### PR DESCRIPTION
Typescript fix: sets the global `defaults` object type to match [what is specified in @types/chart.js](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/chart.js/index.d.ts#L47:L50), rather than an empty object.

Resolves #393  