### PR TITLE
Remove default width and height, and allow null width/height values in Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,13 +19,13 @@ export interface ChartComponentProps {
   getDatasetAtEvent?(e: any): void;
   getElementAtEvent?(e: any): void;
   getElementsAtEvent?(e: any): void;
-  height?: number;
+  height?: number | null;
   legend?: chartjs.ChartLegendOptions;
   onElementsClick?(e: any): void; // alias for getElementsAtEvent (backward compatibility)
   options?: chartjs.ChartOptions;
   plugins?: object[];
   redraw?: boolean;
-  width?: number;
+  width?: number | null;
   datasetKeyProvider?: (any: any) => any;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,6 @@ class ChartComponent extends React.Component {
       position: 'bottom'
     },
     type: 'doughnut',
-    height: 150,
-    width: 300,
     redraw: false,
     options: {},
     datasetKeyProvider: ChartComponent.getLabelAsKey


### PR DESCRIPTION
With the present default width/height values, it's not possible to create charts that fully use the desired aspect ratio. This PR removes the default width/height (which means charts will use the default aspect ratio of 2, as per the chart.js docs, and occupy the full width of their container), and also changes the Typescript definition to make `null` a valid width/height, since that is the only way to remove the width/height that has been set previously.

I confirmed that the tests still pass and examples still draw correctly (though perhaps not all at the dimensions desired!).