### PR TITLE
Remove componentWillMount (Deprecation warning in React 16.9)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,11 @@ import keyBy from 'lodash/keyBy';
 const NODE_ENV = (typeof process !== 'undefined') && process.env && process.env.NODE_ENV;
 
 class ChartComponent extends React.Component {
+  constructor() {
+    super();
+    this.chartInstance = undefined;
+  }
+
   static getLabelAsKey = d => d.label;
 
   static propTypes = {
@@ -46,10 +51,6 @@ class ChartComponent extends React.Component {
     redraw: false,
     options: {},
     datasetKeyProvider: ChartComponent.getLabelAsKey
-  }
-
-  componentWillMount() {
-    this.chartInstance = undefined;
   }
 
   componentDidMount() {
@@ -175,7 +176,7 @@ class ChartComponent extends React.Component {
     var currentDatasets = this.getCurrentDatasets();
     currentDatasets.forEach(d => {
       this.datasets[this.props.datasetKeyProvider(d)] = d;
-    })
+    });
   }
 
   updateChart() {


### PR DESCRIPTION
Fixes https://github.com/jerairrest/react-chartjs-2/issues/405

- Remove use of `componentWillMount` from `ChartComponent`
- Initialize chartInstance as null in the class constructor instead
```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: **ChartComponent**
```