### PR TITLE
Bug fix: Make updateChart robust to missing data in dataset. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,8 @@ class ChartComponent extends React.Component {
       const current =
         currentDatasetsIndexed[this.props.datasetKeyProvider(next)];
 
-      if (current && current.type === next.type) {
+      if (current && current.type === next.type && next.data) {
+        // Be robust to no data. Relevant for other update mechanisms as in chartjs-plugin-streaming.
         // The data array must be edited in place. As chart.js adds listeners to it.
         current.data.splice(next.data.length);
         next.data.forEach((point, pid) => {


### PR DESCRIPTION
When using chartjs-plugin-streaming, the data in datasets is updated by a periodic call to onRefresh or similar function.

In that case, the recommended props to \<Line\> and other charts are datasets with no data property. This works fine until the Component is updated at which time there is a crash because data is not set.

This PR changed updateChart to check if data is present in the new props and only update if it is.