### PR TITLE
Update mix.js

### DIFF
--- a/example/src/components/mix.js
+++ b/example/src/components/mix.js
@@ -58,9 +58,6 @@ const options = {
         id: 'y-axis-1',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       },
       {
@@ -70,9 +67,6 @@ const options = {
         id: 'y-axis-2',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       }
     ]


### PR DESCRIPTION
It was throwing multiple errors, like `labels.slice()` error and `config not defined`. After removing labels object, all errors were gone.
```
labels: {
    show: true
}
```