### PR TITLE
Prevent error in destroyChart when chartInstance does not exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -255,7 +255,9 @@ class ChartComponent extends React.Component {
   }
 
   destroyChart() {
-    if (!this.chartInstance) return;
+    if (!this.chartInstance) {
+          return;
+     }
 
     // Put all of the datasets that have existed in the chart back on the chart
     // so that the metadata associated with this chart get destroyed.

--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,8 @@ class ChartComponent extends React.Component {
   }
 
   destroyChart() {
+    if (!this.chartInstance) return;
+
     // Put all of the datasets that have existed in the chart back on the chart
     // so that the metadata associated with this chart get destroyed.
     // This allows the datasets to be used in another chart. This can happen,


### PR DESCRIPTION
I've seen error this error in my logs:
```
TypeError: Unable to get property 'config' of undefined or null reference
  at ChartComponent.prototype.destroyChart(/vendor.js:46065:21)
  at ChartComponent.prototype.componentWillUnmount(/vendor.js:46001:21)
```

There might be a different issue, but this seems like a safe fix.