### PR TITLE
Make 'redraw' prop work only when 'data' prop is changed in order not to see a graph redrawn scene

### DIFF
--- a/example/src/components/mix.js
+++ b/example/src/components/mix.js
@@ -44,9 +44,6 @@ const options = {
         display: true,
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       }
     ],
@@ -58,9 +55,6 @@ const options = {
         id: 'y-axis-1',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       },
       {
@@ -70,9 +64,6 @@ const options = {
         id: 'y-axis-2',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-chartjs-2",
-  "version": "2.7.6",
+  "version": "2.8.0",
   "description": "react-chartjs-2",
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "author": "Jeremy Ayerst",
   "homepage": "https://github.com/jerairrest/react-chartjs-2",
-  "license" : "MIT" ,
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jerairrest/react-chartjs-2.git"
@@ -35,7 +35,7 @@
     "canvas": "^1.6.2",
     "canvas-prebuilt": "^1.6.5-prerelease.1",
     "chai": "^3.5.0",
-    "chart.js": "2.6.0",
+    "chart.js": "^2.6.0",
     "cross-env": "^5.0.0",
     "css-loader": "^0.28.5",
     "debug": "^2.4.1",


### PR DESCRIPTION
When I set the 'redraw' to true to create a scrolled graph with calculated width according to the number of data, it looks like it is rendered twice. I guess it is not good for UX, so have made 'redraw' prop work only when 'data' prop is changed.