### PR TITLE
Make 'redraw' prop work only when 'data' prop is changed in order not to see a graph redrawn scene

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,8 +57,8 @@ class ChartComponent extends React.Component {
     this.renderChart();
   }
 
-  componentDidUpdate() {
-    if (this.props.redraw) {
+  componentDidUpdate(prevProps) {
+    if (this.props.redraw && (prevProps.data !== this.props.data)) {
       this.destroyChart();
       this.renderChart();
       return;


### PR DESCRIPTION
When I set the 'redraw' to true to create a scrolled graph with calculated width according to the number of data, it looks like it is rendered twice. I guess it is not good for UX, so have made 'redraw' prop work only when 'data' prop is changed.