### PR TITLE
Replace deprecated uglify options compress.warnings with warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,8 +34,8 @@ if (env === 'production') {
         pure_getters: true,
         unsafe: true,
         unsafe_comps: true,
-        warnings: false
       },
+      warnings: true
     })
   );
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ if (env === 'production') {
         unsafe: true,
         unsafe_comps: true,
       },
-      warnings: true
+      warnings: false
     })
   );
 


### PR DESCRIPTION
Fixes [issue 509](https://github.com/jerairrest/react-chartjs-2/issues/509)

Uglify at some point moved the `options.compress.warnings` option to the top level, at `options.warnings`.

Because of this, on a fresh `npm i` you get a (transitive) version of uglify that no longer supports `options.compress.warnings` at all (I guess it was previously deprecated but working) so it breaks the build -- `npm run build` does not work.

This PR just moves that option to the correct location, and it works again.