### PR TITLE
Update `lodash` in package.json to match yarn.lock.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/jerairrest/react-chartjs-2/issues"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.13",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the version of `lodash` in package.json to match the version in the yarn.lock. Without this, `yarn audit` in consuming projects report `react-chartjs-2` as having a high severity vulnerability with `lodash`:

<img width="563" alt="Screen Shot 2020-04-27 at 12 23 37 PM" src="https://user-images.githubusercontent.com/3892771/80401897-b01c6b80-8882-11ea-9ef8-2037c7717b2b.png">

The actual vulnerability appears to have been patched [here](https://github.com/jerairrest/react-chartjs-2/pull/454/files), but without the package json reflecting the change, auditing tools still flag this as vulnerable.